### PR TITLE
Updated contracts to 1.3.2

### DIFF
--- a/HappyTravel.EdoContracts/Accommodations/AccommodationAvailabilityDetails.cs
+++ b/HappyTravel.EdoContracts/Accommodations/AccommodationAvailabilityDetails.cs
@@ -1,31 +1,35 @@
-﻿using System;
-using System.Runtime.InteropServices;
+using System;
+using System.Collections.Generic;
 using HappyTravel.EdoContracts.Accommodations.Internals;
 using Newtonsoft.Json;
 
 namespace HappyTravel.EdoContracts.Accommodations
 {
-    [StructLayout(LayoutKind.Auto)]
-    public readonly struct SingleAccommodationAvailabilityDetailsWithDeadline
+    public readonly struct AccommodationAvailabilityDetails
     {
         [JsonConstructor]
-        public SingleAccommodationAvailabilityDetailsWithDeadline(string availabilityId, DateTime checkInDate,
-            DateTime checkOutDate, int numberOfNights, in AccommodationDetails accommodationDetails, in RoomContractSet roomContractSet)
+        public AccommodationAvailabilityDetails(string availabilityId, DateTime checkInDate, DateTime checkOutDate,
+            int numberOfNights, in SlimAccommodationDetails accommodationDetails, List<RoomContractSet> roomContractSets)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
             CheckOutDate = checkOutDate;
             NumberOfNights = numberOfNights;
             AccommodationDetails = accommodationDetails;
-            RoomContractSet = roomContractSet;
+            RoomContractSets = roomContractSets ?? new List<RoomContractSet>(0);
         }
 
 
         public string AvailabilityId { get; }
+
         public DateTime CheckInDate { get; }
+
         public DateTime CheckOutDate { get; }
+
         public int NumberOfNights { get; }
-        public AccommodationDetails AccommodationDetails { get; }
-        public RoomContractSet RoomContractSet { get; }
+
+        public SlimAccommodationDetails AccommodationDetails { get; }
+
+        public List<RoomContractSet> RoomContractSets { get; }
     }
 }

--- a/HappyTravel.EdoContracts/Accommodations/AccommodationDetails.cs
+++ b/HappyTravel.EdoContracts/Accommodations/AccommodationDetails.cs
@@ -12,7 +12,7 @@ namespace HappyTravel.EdoContracts.Accommodations
         [JsonConstructor]
         public AccommodationDetails(string id, string name, List<string> accommodationAmenities, Dictionary<string, string> additionalInfo,
             string category, in ContactInfo contacts, in LocationInfo location, List<Picture> pictures, AccommodationRatings rating,
-            List<string> roomAmenities, in ScheduleInfo schedule, List<TextualDescription> textualDescriptions, PropertyTypes type, string typeDescription)
+            in ScheduleInfo schedule, List<TextualDescription> textualDescriptions, PropertyTypes type)
         {
             Id = id;
             AccommodationAmenities = accommodationAmenities ?? new List<string>(0);
@@ -23,11 +23,9 @@ namespace HappyTravel.EdoContracts.Accommodations
             Location = location;
             Name = name;
             Pictures = pictures ?? new List<Picture>(0);
-            RoomAmenities = roomAmenities ?? new List<string>(0);
             Schedule = schedule;
             TextualDescriptions = textualDescriptions ?? new List<TextualDescription>(0);
             Type = type;
-            TypeDescription = typeDescription;
         }
 
 
@@ -81,20 +79,12 @@ namespace HappyTravel.EdoContracts.Accommodations
         /// </summary>
         public PropertyTypes Type { get; }
 
-        /// <summary>
-        ///     Description of a property type
-        /// </summary>
-        public string TypeDescription { get; }
 
         /// <summary>
         ///     Dictionary of amenities available in an accommodation
         /// </summary>
         public List<string> AccommodationAmenities { get; }
 
-        /// <summary>
-        ///     Dictionary of amenities available in rooms
-        /// </summary>
-        public List<string> RoomAmenities { get; }
 
         /// <summary>
         ///     Dictionary of all other accommodation stats

--- a/HappyTravel.EdoContracts/Accommodations/AvailabilityDetails.cs
+++ b/HappyTravel.EdoContracts/Accommodations/AvailabilityDetails.cs
@@ -11,14 +11,14 @@ namespace HappyTravel.EdoContracts.Accommodations
     public readonly struct AvailabilityDetails
     {
         [JsonConstructor]
-        public AvailabilityDetails(string availabilityId, int numberOfNights, DateTime checkInDate, DateTime checkOutDate, List<Internals.AccommodationAvailabilityDetails> results, int numberOfProcessedAccommodations = 0)
+        public AvailabilityDetails(string availabilityId, int numberOfNights, DateTime checkInDate, DateTime checkOutDate, List<Internals.AccommodationAvailability> results, int numberOfProcessedAccommodations = 0)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
             CheckOutDate = checkOutDate;
             NumberOfNights = numberOfNights;
             NumberOfProcessedAccommodations = numberOfProcessedAccommodations;
-            Results = results ?? new List<Internals.AccommodationAvailabilityDetails>(0);
+            Results = results ?? new List<AccommodationAvailability>(0);
         }
 
 
@@ -27,7 +27,7 @@ namespace HappyTravel.EdoContracts.Accommodations
         public DateTime CheckOutDate { get; }
         public int NumberOfNights { get; }
         public int NumberOfProcessedAccommodations { get; }
-        public List<Internals.AccommodationAvailabilityDetails> Results { get; }
+        public List<AccommodationAvailability> Results { get; }
 
 
         public override bool Equals(object? obj) => obj is AvailabilityDetails other && Equals(other);

--- a/HappyTravel.EdoContracts/Accommodations/AvailabilityDetails.cs
+++ b/HappyTravel.EdoContracts/Accommodations/AvailabilityDetails.cs
@@ -11,14 +11,14 @@ namespace HappyTravel.EdoContracts.Accommodations
     public readonly struct AvailabilityDetails
     {
         [JsonConstructor]
-        public AvailabilityDetails(string availabilityId, int numberOfNights, DateTime checkInDate, DateTime checkOutDate, List<AccommodationAvailabilityDetails> results, int numberOfProcessedAccommodations = 0)
+        public AvailabilityDetails(string availabilityId, int numberOfNights, DateTime checkInDate, DateTime checkOutDate, List<Internals.AccommodationAvailabilityDetails> results, int numberOfProcessedAccommodations = 0)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
             CheckOutDate = checkOutDate;
             NumberOfNights = numberOfNights;
             NumberOfProcessedAccommodations = numberOfProcessedAccommodations;
-            Results = results ?? new List<AccommodationAvailabilityDetails>(0);
+            Results = results ?? new List<Internals.AccommodationAvailabilityDetails>(0);
         }
 
 
@@ -27,7 +27,7 @@ namespace HappyTravel.EdoContracts.Accommodations
         public DateTime CheckOutDate { get; }
         public int NumberOfNights { get; }
         public int NumberOfProcessedAccommodations { get; }
-        public List<AccommodationAvailabilityDetails> Results { get; }
+        public List<Internals.AccommodationAvailabilityDetails> Results { get; }
 
 
         public override bool Equals(object? obj) => obj is AvailabilityDetails other && Equals(other);

--- a/HappyTravel.EdoContracts/Accommodations/Internals/AccommodationAvailability.cs
+++ b/HappyTravel.EdoContracts/Accommodations/Internals/AccommodationAvailability.cs
@@ -6,10 +6,10 @@ using Newtonsoft.Json;
 namespace HappyTravel.EdoContracts.Accommodations.Internals
 {
     [StructLayout(LayoutKind.Auto)]
-    public readonly struct AccommodationAvailabilityDetails
+    public readonly struct AccommodationAvailability
     {
         [JsonConstructor]
-        public AccommodationAvailabilityDetails(in SlimAccommodationDetails accommodationDetails, List<RoomContractSet> roomContractSets)
+        public AccommodationAvailability(in SlimAccommodationDetails accommodationDetails, List<RoomContractSet> roomContractSets)
         {
             AccommodationDetails = accommodationDetails;
             RoomContractSets = roomContractSets ?? new List<RoomContractSet>(0);
@@ -20,10 +20,10 @@ namespace HappyTravel.EdoContracts.Accommodations.Internals
         public List<RoomContractSet> RoomContractSets { get; }
 
 
-        public override bool Equals(object? obj) => obj is AccommodationAvailabilityDetails other && Equals(other);
+        public override bool Equals(object? obj) => obj is AccommodationAvailability other && Equals(other);
 
 
-        public bool Equals(AccommodationAvailabilityDetails other)
+        public bool Equals(AccommodationAvailability other)
             => AccommodationDetails
                     .Equals(other.AccommodationDetails) &&
                 RoomContractSets.SafeSequenceEqual(other.RoomContractSets);

--- a/HappyTravel.EdoContracts/Accommodations/RoomContractSetAvailability.cs
+++ b/HappyTravel.EdoContracts/Accommodations/RoomContractSetAvailability.cs
@@ -1,35 +1,31 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
+using System.Runtime.InteropServices;
 using HappyTravel.EdoContracts.Accommodations.Internals;
 using Newtonsoft.Json;
 
 namespace HappyTravel.EdoContracts.Accommodations
 {
-    public readonly struct SingleAccommodationAvailabilityDetails
+    [StructLayout(LayoutKind.Auto)]
+    public readonly struct RoomContractSetAvailability
     {
         [JsonConstructor]
-        public SingleAccommodationAvailabilityDetails(string availabilityId, DateTime checkInDate, DateTime checkOutDate,
-            int numberOfNights, in AccommodationDetails accommodationDetails, List<RoomContractSet> roomContractSets)
+        public RoomContractSetAvailability(string availabilityId, DateTime checkInDate,
+            DateTime checkOutDate, int numberOfNights, in SlimAccommodationDetails accommodationDetails, in RoomContractSet roomContractSet)
         {
             AvailabilityId = availabilityId;
             CheckInDate = checkInDate;
             CheckOutDate = checkOutDate;
             NumberOfNights = numberOfNights;
             AccommodationDetails = accommodationDetails;
-            RoomContractSets = roomContractSets ?? new List<RoomContractSet>(0);
+            RoomContractSet = roomContractSet;
         }
 
 
         public string AvailabilityId { get; }
-
         public DateTime CheckInDate { get; }
-
         public DateTime CheckOutDate { get; }
-
         public int NumberOfNights { get; }
-
-        public AccommodationDetails AccommodationDetails { get; }
-
-        public List<RoomContractSet> RoomContractSets { get; }
+        public SlimAccommodationDetails AccommodationDetails { get; }
+        public RoomContractSet RoomContractSet { get; }
     }
 }

--- a/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
+++ b/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
@@ -12,8 +12,8 @@
         <PackageReleaseNotes>Changed BoardBasis Serialization</PackageReleaseNotes>
         <PackageProjectUrl>https://github.com/happy-travel/edo-contracts</PackageProjectUrl>
         <RepositoryURL>https://github.com/happy-travel/edo-contracts</RepositoryURL>
-        <Version>1.3.1.3</Version>
-        <PackageVersion>1.3.1.3</PackageVersion>
+        <Version>1.3.2</Version>
+        <PackageVersion>1.3.2</PackageVersion>
     </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Due to task created earlier:
```
    Everywhere in availability results return 

    SlimAccommodationDetails instead of AccommodationDetails. 

    AccommodationDetails- remove roomAmenities, remove typeDescription

+ Discuss and think about renaming “SingleAccommodationAvailabilityDetailsWithDeadline“ to more appropriate, maybe with “SinglRoomContractSet..“ in name

```

+ renamed SingleAccommodationAvailabilityDetails to AccommodationAvailabilityDetails
+ renamed SingleAccommodationAvailabilityDetailsWithDeadline to RoomContractSetAvailabilityDetails