### PR TITLE
Fix the TryGetBookingFailureCode method

### DIFF
--- a/HappyTravel.EdoContracts/Errors/BookingErrorDetailsDictionaryExtensions.cs
+++ b/HappyTravel.EdoContracts/Errors/BookingErrorDetailsDictionaryExtensions.cs
@@ -17,13 +17,13 @@ namespace HappyTravel.EdoContracts.Errors
 
         public static bool TryGetBookingFailureCode(this IDictionary<string, object> extensions, out BookingFailureCodes failureCode)
         {
-            if (!extensions.TryGetValue(BookingFailureCodeKey, out var code))
+            if (!extensions.TryGetValue(BookingFailureCodeKey, out var code) || !(code is string codeValue))
             {
                 failureCode = BookingFailureCodes.Unknown;
                 return false;
             }
-
-            failureCode = (BookingFailureCodes) code;
+            
+            failureCode = Enum.Parse<BookingFailureCodes>(codeValue);
             return true;
         }
         

--- a/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
+++ b/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
@@ -9,11 +9,12 @@
         <Company>HappyTravel</Company>
         <Authors>Hasmik Harutyunyan, Oleg Konovalov, Vadim Mingazhev, Kirill Taran</Authors>
         <Description>Inter-service contracts for accommodation data transfer etc.</Description>
-        <PackageReleaseNotes>Added HasDirectContract flag to MultilingualAccommodation</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixed the TryGetBookingFailureCode method</PackageReleaseNotes>
         <PackageProjectUrl>https://github.com/happy-travel/edo-contracts</PackageProjectUrl>
         <RepositoryURL>https://github.com/happy-travel/edo-contracts</RepositoryURL>
         <Version>1.6.8</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageVersion>1.6.9</PackageVersion>
     </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix the TryGetBookingFailureCode method
(System.InvalidCastException: Unable to cast object of type 'System.String' to type 'HappyTravel.EdoContracts.Accommodations.Enums.BookingFailureCodes'.)