### PR TITLE
Added credit cards bookings support

### DIFF
--- a/HappyTravel.EdoContracts/Accommodations/BookingRequest.cs
+++ b/HappyTravel.EdoContracts/Accommodations/BookingRequest.cs
@@ -11,11 +11,12 @@ namespace HappyTravel.EdoContracts.Accommodations
     {
         [JsonConstructor]
         public BookingRequest(string availabilityId, in Guid roomContractSetId, string referenceCode, List<SlimRoomOccupation> rooms, List<Feature> features,
-            bool rejectIfUnavailable = true)
+            CreditCard? creditCard = null, bool rejectIfUnavailable = true)
         {
             AvailabilityId = availabilityId;
             RoomContractSetId = roomContractSetId;
             ReferenceCode = referenceCode;
+            CreditCard = creditCard;
             RejectIfUnavailable = rejectIfUnavailable;
 
             Rooms = rooms ?? new List<SlimRoomOccupation>(0);
@@ -37,6 +38,11 @@ namespace HappyTravel.EdoContracts.Accommodations
         ///     The Happytravel.com reference code.
         /// </summary>
         public string ReferenceCode { get; }
+
+        /// <summary>
+        /// Credit card needed for booking
+        /// </summary>
+        public CreditCard? CreditCard { get; }
 
         /// <summary>
         ///     If the flag is set a booking will be rejected in case of unavailability. In the other case the booking will be

--- a/HappyTravel.EdoContracts/Accommodations/Internals/CreditCard.cs
+++ b/HappyTravel.EdoContracts/Accommodations/Internals/CreditCard.cs
@@ -1,0 +1,37 @@
+using System;
+using Newtonsoft.Json;
+
+namespace HappyTravel.EdoContracts.Accommodations.Internals
+{
+    public readonly struct CreditCard
+    {
+        [JsonConstructor]
+        public CreditCard(string number, DateTime expiry, string holder, string code)
+        {
+            Number = number;
+            Expiry = expiry;
+            Holder = holder;
+            Code = code;
+        }
+        
+        /// <summary>
+        /// Credit card number
+        /// </summary>
+        public string Number { get; }
+        
+        /// <summary>
+        /// Expiration date
+        /// </summary>
+        public DateTime Expiry { get; }
+        
+        /// <summary>
+        /// Card holder name
+        /// </summary>
+        public string Holder { get; }
+        
+        /// <summary>
+        /// Card sectr
+        /// </summary>
+        public string Code { get; }
+    }
+}

--- a/HappyTravel.EdoContracts/Accommodations/Internals/CreditCard.cs
+++ b/HappyTravel.EdoContracts/Accommodations/Internals/CreditCard.cs
@@ -30,7 +30,7 @@ namespace HappyTravel.EdoContracts.Accommodations.Internals
         public string Holder { get; }
         
         /// <summary>
-        /// Card sectr
+        /// Card secret code (CVC)
         /// </summary>
         public string Code { get; }
     }

--- a/HappyTravel.EdoContracts/Accommodations/RoomContractSetAvailability.cs
+++ b/HappyTravel.EdoContracts/Accommodations/RoomContractSetAvailability.cs
@@ -10,7 +10,7 @@ namespace HappyTravel.EdoContracts.Accommodations
     {
         [JsonConstructor]
         public RoomContractSetAvailability(string availabilityId, string accommodationId, DateTime checkInDate,
-            DateTime checkOutDate, int numberOfNights, RoomContractSet roomContractSet)
+            DateTime checkOutDate, int numberOfNights, RoomContractSet roomContractSet, bool isCreditCardNeeded)
         {
             AvailabilityId = availabilityId;
             AccommodationId = accommodationId;
@@ -18,6 +18,7 @@ namespace HappyTravel.EdoContracts.Accommodations
             CheckOutDate = checkOutDate;
             NumberOfNights = numberOfNights;
             RoomContractSet = roomContractSet;
+            IsCreditCardNeeded = isCreditCardNeeded;
         }
 
 
@@ -50,5 +51,10 @@ namespace HappyTravel.EdoContracts.Accommodations
         ///     Information about a selected room contract set.
         /// </summary>
         public RoomContractSet RoomContractSet { get; }
+
+        /// <summary>
+        /// True if credit card need to be passed in booking request
+        /// </summary>
+        public bool IsCreditCardNeeded { get; }
     }
 }

--- a/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
+++ b/HappyTravel.EdoContracts/HappyTravel.EdoContracts.csproj
@@ -8,12 +8,12 @@
     <Company>HappyTravel</Company>
     <Authors>Hasmik Harutyunyan, Oleg Konovalov, Vadim Mingazhev, Kirill Taran</Authors>
     <Description>Inter-service contracts for accommodation data transfer etc.</Description>
-    <PackageReleaseNotes>Updated HappyTravel.Money package version</PackageReleaseNotes>
+    <PackageReleaseNotes>Added credit card bookings support</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/happy-travel/edo-contracts</PackageProjectUrl>
     <RepositoryURL>https://github.com/happy-travel/edo-contracts</RepositoryURL>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageVersion>2.0.2</PackageVersion>
+    <PackageVersion>2.1.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="HappyTravel.MultiLanguage" Version="1.0.2" />


### PR DESCRIPTION
The idea is to:
- Get if credit card is needed, from evaluation response. For now field `isCreditCardNeeded` will be set to `true` for Jumeirah only
- Send credit card details in booking request if it is needed

https://github.com/happy-travel/agent-app-project/issues/557